### PR TITLE
Exposing page type so that is possible to write type signatures

### DIFF
--- a/src/Application/Page.elm
+++ b/src/Application/Page.elm
@@ -6,6 +6,7 @@ module Application.Page exposing
     , layout
     , recipe
     , keep
+    , Page
     )
 
 {-| Each page can be as simple or complex as you need:


### PR DESCRIPTION
I was not able to write the type signature of a page because the type "Page" is not exposed:

```
page : Page.Page () Model Msg (Html Msg) layoutModel layoutMsg uiLayoutMsg Global.Model Global.Msg msg uiMsg
```