### PR TITLE
check whether the folder exists before attempting to create it, avoid…

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -37,7 +37,7 @@ const listFiles = (dir) =>
       [])
 
 const ensureDirectory = (dir) =>
-  fs.mkdirSync(dir, { recursive: true })
+  fs.existsSync(dir) || fs.mkdirSync(dir, { recursive: true })
 
 const saveToFolder = (prefix) => ({ filepath, content }) =>
   fs.writeFileSync(path.join(prefix, filepath), content, { encoding: 'utf8' })


### PR DESCRIPTION
See my steps to reproduce error, plus pull request to fix.

Steps to reproduce:

```
$ npm install -g elm-spa@latest
...
$ elm-spa init newproj

created a new project in /Users/tom/tmp/newproj

$ cd newproj
$ elm-spa add static Test.One

added a new static page at:
/Users/tom/tmp/newproj/src/Pages/Test/One.elm

$ elm-spa add static Test.Two

please run elm-spa add in the folder with elm.json
```

Debugged the issue into cli/index.js and specifically the ensureDirectory(..) function which performs a fs.mkdirSync(..) on the parent directory. This seems to throw an exception if the folder already exists and therefore rejects the promise resulting in the error above. 

This fixes my problem and I can now run the above steps without error and with correct results.