### PR TITLE
Fix nested dynamic route example

### DIFF
--- a/examples/elm-spa-dev/public/content/guide/routing.md
+++ b/examples/elm-spa-dev/public/content/guide/routing.md
@@ -53,7 +53,7 @@ __Supported Parameters__: Only `String` and `Int` dynamic parameters are support
 You can also nest your dynamic routes. Here's an example:
 
 
-__`Users/User_String/Posts/Post_Int.elm`__
+__`Users/User_String/Posts/Id_Int.elm`__
 
 URL | Params
 :-- | :--


### PR DESCRIPTION
Noticed the example for nested dynamic routes shows `id` as a param instead of `post`. 

The example could be fixed by updating param name to `post` or the path to `Users/User_String/Posts/Id_Int.elm` . I went with updating the path because it matches the Dynamic Routes example.