### PR TITLE
Save share after main init

### DIFF
--- a/templates/elm-css/src/Main.elm
+++ b/templates/elm-css/src/Main.elm
@@ -39,8 +39,11 @@ init flags url key =
 
         ( page, pageCmd ) =
             Pages.init (fromUrl url) shared
+
+        savedShare =
+            Pages.save page shared
     in
-    ( Model shared page
+    ( Model savedShare page
     , Cmd.batch
         [ Cmd.map Shared sharedCmd
         , Cmd.map Pages pageCmd

--- a/templates/elm-ui/src/Main.elm
+++ b/templates/elm-ui/src/Main.elm
@@ -39,8 +39,11 @@ init flags url key =
 
         ( page, pageCmd ) =
             Pages.init (fromUrl url) shared
+
+        savedShare =
+            Pages.save page shared
     in
-    ( Model shared page
+    ( Model savedShare page
     , Cmd.batch
         [ Cmd.map Shared sharedCmd
         , Cmd.map Pages pageCmd

--- a/templates/html/src/Main.elm
+++ b/templates/html/src/Main.elm
@@ -39,8 +39,11 @@ init flags url key =
 
         ( page, pageCmd ) =
             Pages.init (fromUrl url) shared
+
+        savedShare =
+            Pages.save page shared
     in
-    ( Model shared page
+    ( Model savedShare page
     , Cmd.batch
         [ Cmd.map Shared sharedCmd
         , Cmd.map Pages pageCmd


### PR DESCRIPTION
This keeps a possible change in the shared model after the first init in main.

My use case was redirecting from the landing page based on the Url with a Navigation command returned from that page's init, and needing to keep data in the shared model extracted from the Url in that same init.