### PR TITLE
Add option to launch server using HTTPS

### DIFF
--- a/src/cli/src/new/README.md
+++ b/src/cli/src/new/README.md
@@ -12,7 +12,9 @@ npm install -g elm elm-spa
 ## running locally
 
 ```bash
-elm-spa server  # starts this app at http:/localhost:1234
+elm-spa server                   # starts this app at http:/localhost:1234
+elm-spa server ssl_cert ssl_key  # starts this app at https:/localhost:1234
+
 ```
 
 ### other commands


### PR DESCRIPTION
I like to run my dev servers w/ HTTPS.  That way I get warnings if anyone hard codes an HTTP url and allows remote demos, etc. without worrying about what data is transmitted.

Please let me know if this works for you.