### PR TITLE
Remove redundant route generation

### DIFF
--- a/src/cli/src/cli/build.ts
+++ b/src/cli/src/cli/build.ts
@@ -122,7 +122,6 @@ const createGeneratedFiles = async () => {
     { filepath: ['Page'], contents: PageTemplate() },
     { filepath: ['Request'], contents: RequestTemplate() },
     { filepath: ['Gen', 'Route'], contents: RouteTemplate(segments, options(kindForPage)) },
-    { filepath: ['Gen', 'Route'], contents: RouteTemplate(segments, options(kindForPage)) },
     { filepath: ['Gen', 'Pages'], contents: PagesTemplate(segments, options(kindForPage)) },
     { filepath: ['Gen', 'Model'], contents: ModelTemplate(segments, options(kindForPage)) },
     { filepath: ['Gen', 'Msg'], contents: MsgTemplate(segments, options(kindForPage)) }


### PR DESCRIPTION
I noticed this line is called twice. I could be mistaken but believe one time should be enough.

```
{ filepath: ['Gen', 'Route'], contents: RouteTemplate(segments, options(kindForPage)) },
```

https://github.com/ryannhg/elm-spa/blob/main/src/cli/src/cli/build.ts#L124-L125