### PR TITLE
adding-a-sign-in-page: fix wrong sig (documentation)

### DIFF
--- a/docs/public/content/examples/04-authentication.md
+++ b/docs/public/content/examples/04-authentication.md
@@ -230,8 +230,9 @@ update msg model =
 
 ```elm
 -- Make view show a sign out button
+-- We must return the concrete type `Msg` because we use ClickedSignIn
 
-view : Model -> Html msg
+view : Model -> View Msg
 view model =
     { title = "Sign In"
     , body =


### PR DESCRIPTION
Plus I added a little hint for beginners (concrete vs unbound type variables confused me when I looked at elm-spa the first time)