### PR TITLE
Update 01-hello-world.md / .gitignore section

### DIFF
--- a/docs/public/content/examples/01-hello-world.md
+++ b/docs/public/content/examples/01-hello-world.md
@@ -120,12 +120,12 @@ The files in `.elm-spa/generated` should not be changed, so they are stored in a
 By default, a `.gitignore` file is generated to promote best practices when working with __elm-spa__ and your git repo:
 
 ```
-.elm-spa
+.elm-spa/generated
 elm-stuff
 dist
 ```
 
-Notice that the `.elm-spa` folder is __ignored from git__. You shouldn't push any generated __elm-spa__ code to your repo. Instead, use commands like `elm-spa build` to reliably regenerate these files during deployments.
+Notice that the `.elm-spa/generated` folder is __ignored from git__. You shouldn't push any generated __elm-spa__ code to your repo. Instead, use commands like `elm-spa build` to reliably regenerate these files during deployments.
 
 ```terminal
 elm-spa build


### PR DESCRIPTION
Add the `.elm-spa/generated` folder instead of `.elm-spa` to the .gitignore file because files inside `.elm-spa/defaults` and `.elm-spa/templates` get generated only once and can be changed by the user later in the development process and hence should be committed to the repository