### PR TITLE
docs: Update dead link to Parcel

### DIFF
--- a/docs/public/content/guide/01-cli.md
+++ b/docs/public/content/guide/01-cli.md
@@ -109,7 +109,7 @@ If you are working with another dev server, you won't need the `.js` file genera
 elm-spa gen
 ```
 
-This will generate code in the `.elm-spa` folder, but allow your custom workflow to define it's own way of compiling Elm. This is a great command to combine __elm-spa__ with another tool like [Vite](https://vitejs.dev) or [Parcel](https://parceljs.org/elm.html).
+This will generate code in the `.elm-spa` folder, but allow your custom workflow to define it's own way of compiling Elm. This is a great command to combine __elm-spa__ with another tool like [Vite](https://vitejs.dev) or [Parcel](https://parceljs.org/languages/elm/).
 
 
 ## elm-spa watch


### PR DESCRIPTION
I couldn't find URL changed commit in https://github.com/parcel-bundler/website, however it looks applied new URL.

<img width="775" alt="parcel-old" src="https://user-images.githubusercontent.com/1180335/176569487-23692b84-48bc-4bff-973f-7ee77d9aa1af.png">
<img width="667" alt="parcel-new" src="https://user-images.githubusercontent.com/1180335/176569484-b1b825fb-c016-44d6-acf9-3f9b68aa5ba8.png">

