### PR TITLE
Don't lose equal signs in query param values

### DIFF
--- a/src/ElmSpa/Request.elm
+++ b/src/ElmSpa/Request.elm
@@ -109,7 +109,7 @@ query str =
                     >> (\eq ->
                             Maybe.map2 Tuple.pair
                                 (List.head eq)
-                                (eq |> List.drop 1 |> List.head |> Maybe.withDefault "" |> Just)
+                                (eq |> List.drop 1 |> String.join "=" |> Just)
                        )
                 )
             |> List.map (Tuple.mapBoth decode decode)


### PR DESCRIPTION
Query parameter values can contain equal signs. The current implementation only retains the part before the equal sign.

I encountered it when a query parameter value contained a Base64 encoded value. The trailing '=' was dropped. This change rejoins the parameter value parts with '='