### PR TITLE
Fix typo in link

### DIFF
--- a/docs/public/content/examples/02-pages.md
+++ b/docs/public/content/examples/02-pages.md
@@ -211,7 +211,7 @@ elm-spa add /element element
 elm-spa add /advanced advanced
 ```
 
-These commands add in the other three page types described in the [pages guide](/guides/03-pages).
+These commands add in the other three page types described in the [pages guide](/guide/03-pages).
 
 For each page, the `View.placeholder` function stubs out the `view` functions so you can visit them in the browser.
 


### PR DESCRIPTION
The current link points to

https://www.elm-spa.dev/guides/03-pages (error 404, not found)

The fix updates it to:

https://www.elm-spa.dev/guide/03-pages
